### PR TITLE
chore: Update Flatpak commit reference for TSX Viewer module

### DIFF
--- a/src/flatpak/flatpak.yml
+++ b/src/flatpak/flatpak.yml
@@ -25,7 +25,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/01esyaLebedeva/tsx_viewer.git
-        commit: be2d917f5c5bf783615ac7c16d814ed3f8616b5f
+        commit: be812c1b2f94cb727d3f282ccbf2be0efb23dd29
 
   - name: tsx_viewer
     buildsystem: simple
@@ -49,7 +49,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/01esyaLebedeva/tsx_viewer.git
-        commit: be2d917f5c5bf783615ac7c16d814ed3f8616b5f
+        commit: be812c1b2f94cb727d3f282ccbf2be0efb23dd29
 
 finish-args:
   - --share=network


### PR DESCRIPTION
This commit updates the Flatpak configuration to reference a new commit of the TSX Viewer repository, ensuring the build uses the latest changes. The previous commit reference has been replaced to maintain up-to-date integration with the source code.