### PR TITLE
feat: Implement locale detection and update in Electron app

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -14,10 +14,33 @@ function createWindow() {
     },
   });
 
+  // Detect user's system locale
+  const locale = app.getLocale();
+
+  // Send the locale to the renderer process when the window is ready
+  win.webContents.on('did-finish-load', () => {
+    win.webContents.send('locale-update', locale);
+  });
+
   if (isDev) {
     win.loadURL('https://localhost:8081/');
   } else {
     win.loadFile(path.join(__dirname, '../dist/index.html'));
+
+  // Detect user's system locale
+  const locale = app.getLocale();
+
+  // Send the locale to the renderer process when the window is ready
+  win.webContents.on('did-finish-load', () => {
+    win.webContents.send('locale-update', locale);
+  });
+    // Detect user's system locale
+    const locale = app.getLocale();
+  
+    // Send the locale to the renderer process when the window is ready
+    win.webContents.on('did-finish-load', () => {
+      win.webContents.send('locale-update', locale);
+    });
   }
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,11 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { SandpackProvider, SandpackLayout, SandpackCodeEditor, SandpackPreview } from "@codesandbox/sandpack-react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { Upload, Code, Edit } from 'lucide-react';
 import './index.css';
 import { useTranslation, Trans } from 'react-i18next';
+import { ipcRenderer } from 'electron'; // Import ipcRenderer
+import i18n from './i18n'; // Import i18n instance
 
 const PRELOAD_DEPENDENCIES = {
   "react": "^18.2.0",
@@ -25,6 +27,27 @@ const App: React.FC = () => {
   const [isEditorActive, setIsEditorActive] = useState(false);
   const [showPreview, setShowPreview] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+
+  // IPC Listener for locale updates
+  useEffect(() => {
+    const handleLocaleUpdate = (event: any, locale: string) => {
+      console.log('Received locale:', locale); // For debugging
+      i18n.changeLanguage(locale);
+    };
+
+    // Check if ipcRenderer is available (it might not be in a non-Electron environment)
+    // Assuming preload script exposes ipcRenderer as window.electron.ipcRenderer
+    if (window.electron?.ipcRenderer) {
+      window.electron.ipcRenderer.on('locale-update', handleLocaleUpdate);
+    }
+
+    // Cleanup function to remove the listener when the component unmounts
+    return () => {
+      if (window.electron?.ipcRenderer) {
+        window.electron.ipcRenderer.removeListener('locale-update', handleLocaleUpdate);
+      }
+    };
+  }, []); // Empty dependency array means this effect runs once on mount and cleans up on unmount
 
   const fileInputRef = useRef<HTMLInputElement>(null);
 

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -9,7 +9,7 @@ i18n
   .use(initReactI18next)
   .init({
     fallbackLng: 'en',
-    debug: true,
+    debug: import.meta.env.DEV,
     interpolation: {
       escapeValue: false,
     },


### PR DESCRIPTION
This commit adds functionality to detect the user's system locale in the Electron main process and sends it to the renderer process upon window load. The App component is updated to listen for locale updates via IPC and change the language accordingly using the i18n instance. Additionally, the i18n configuration is modified to enable debug mode based on the environment.